### PR TITLE
Update query table name

### DIFF
--- a/docs/database/ftl.md
+++ b/docs/database/ftl.md
@@ -54,7 +54,7 @@ Label | Type | Allowed to by empty | Content
 `reply_time` | real | Yes | Seconds it took until the final reply was received
 `dnssec` | integer | Yes | Type of the DNSSEC status for this query  (see [DNSSEC status](ftl.md#dnssec-status))
 
-The `queries` `VIEW` is dynamically generated from the data actually stored in the tables `queries_storage` and the linking tables `domain_by_id`, `client_by_id`, `forward_by_id`, and `addinfo_by_id` (see below). The table `queries_storage` will contains integer IDs pointing to the respective entries of the linking tables to save space and make searching the database faster. If you haven't upgraded for some time, the table may still contain strings instead of integer IDs.
+The `queries` `VIEW` is dynamically generated from the data actually stored in the tables `query_storage` and the linking tables `domain_by_id`, `client_by_id`, `forward_by_id`, and `addinfo_by_id` (see below). The table `query_storage` will contains integer IDs pointing to the respective entries of the linking tables to save space and make searching the database faster. If you haven't upgraded for some time, the table may still contain strings instead of integer IDs.
 
 #### Data-dependent `additional_info` field
 


### PR DESCRIPTION
Update query table name from `queries_storage` to `query_storage` to reflect changes in [pi-hole/FTL](https://github.com/pi-hole/FTL/commit/beae1b3bf5681156e3ed5f2468c0208145312715).